### PR TITLE
Add TypeScript config across packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,15 @@
     "@changesets/cli": "^2.27.7",
     "@commitlint/cli": "17.x",
     "@commitlint/config-conventional": "17.x",
+    "@types/node": "^18",
+    "@types/react": "^18",
     "@tonic-ui/changelog-github": "workspace:*",
     "husky": "8.x",
-    "lerna": "7.x"
+    "lerna": "7.x",
+    "@rollup/plugin-typescript": "^11.1.6",
+    "ts-jest": "^29.0.0",
+    "ts-node": "^10.0.0",
+    "typescript": "^5.0.0"
   },
   "packageManager": "yarn@3.2.4"
 }

--- a/packages/changelog-github/rollup.config.mjs
+++ b/packages/changelog-github/rollup.config.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { codecovRollupPlugin } from '@codecov/rollup-plugin';
 import { babel } from '@rollup/plugin-babel';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
 
 const pkg = createRequire(import.meta.url)('./package.json');
 const __filename = fileURLToPath(import.meta.url);
@@ -29,6 +30,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({
@@ -48,6 +50,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({

--- a/packages/changelog-github/tsconfig.json
+++ b/packages/changelog-github/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types",
+    "rootDir": "./src",
+    "composite": true,
+    "allowJs": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/packages/codemod/tsconfig.json
+++ b/packages/codemod/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types",
+    "rootDir": "./src",
+    "composite": true,
+    "allowJs": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/packages/react-base/rollup.config.mjs
+++ b/packages/react-base/rollup.config.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { codecovRollupPlugin } from '@codecov/rollup-plugin';
 import { babel } from '@rollup/plugin-babel';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
 
 const pkg = createRequire(import.meta.url)('./package.json');
 const __filename = fileURLToPath(import.meta.url);
@@ -28,6 +29,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({
@@ -47,6 +49,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({

--- a/packages/react-base/tsconfig.json
+++ b/packages/react-base/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types",
+    "rootDir": "./src",
+    "composite": true,
+    "allowJs": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/packages/react-docs/tsconfig.json
+++ b/packages/react-docs/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types",
+    "rootDir": "./",
+    "composite": true,
+    "allowJs": true,
+    "declaration": true
+  },
+  "include": ["."]
+}

--- a/packages/react-hooks/rollup.config.mjs
+++ b/packages/react-hooks/rollup.config.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { codecovRollupPlugin } from '@codecov/rollup-plugin';
 import { babel } from '@rollup/plugin-babel';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
 
 const pkg = createRequire(import.meta.url)('./package.json');
 const __filename = fileURLToPath(import.meta.url);
@@ -29,6 +30,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({
@@ -48,6 +50,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({

--- a/packages/react-hooks/tsconfig.json
+++ b/packages/react-hooks/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types",
+    "rootDir": "./src",
+    "composite": true,
+    "allowJs": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/packages/react-icons/rollup.config.mjs
+++ b/packages/react-icons/rollup.config.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { codecovRollupPlugin } from '@codecov/rollup-plugin';
 import { babel } from '@rollup/plugin-babel';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
 
 const pkg = createRequire(import.meta.url)('./package.json');
 const __filename = fileURLToPath(import.meta.url);
@@ -28,6 +29,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({
@@ -47,6 +49,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({

--- a/packages/react-icons/tsconfig.json
+++ b/packages/react-icons/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types",
+    "rootDir": "./src",
+    "composite": true,
+    "allowJs": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { codecovRollupPlugin } from '@codecov/rollup-plugin';
 import { babel } from '@rollup/plugin-babel';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
 
 const pkg = createRequire(import.meta.url)('./package.json');
 const __filename = fileURLToPath(import.meta.url);
@@ -28,6 +29,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({
@@ -47,6 +49,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types",
+    "rootDir": "./src",
+    "composite": true,
+    "allowJs": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/packages/styled-system/rollup.config.mjs
+++ b/packages/styled-system/rollup.config.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { codecovRollupPlugin } from '@codecov/rollup-plugin';
 import { babel } from '@rollup/plugin-babel';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
 
 const pkg = createRequire(import.meta.url)('./package.json');
 const __filename = fileURLToPath(import.meta.url);
@@ -29,6 +30,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({
@@ -48,6 +50,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({

--- a/packages/styled-system/tsconfig.json
+++ b/packages/styled-system/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types",
+    "rootDir": "./src",
+    "composite": true,
+    "allowJs": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/packages/theme/rollup.config.mjs
+++ b/packages/theme/rollup.config.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { codecovRollupPlugin } from '@codecov/rollup-plugin';
 import { babel } from '@rollup/plugin-babel';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
 
 const pkg = createRequire(import.meta.url)('./package.json');
 const __filename = fileURLToPath(import.meta.url);
@@ -37,6 +38,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({
@@ -56,6 +58,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types",
+    "rootDir": "./src",
+    "composite": true,
+    "allowJs": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/packages/utils/rollup.config.mjs
+++ b/packages/utils/rollup.config.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { codecovRollupPlugin } from '@codecov/rollup-plugin';
 import { babel } from '@rollup/plugin-babel';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
 
 const pkg = createRequire(import.meta.url)('./package.json');
 const __filename = fileURLToPath(import.meta.url);
@@ -29,6 +30,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({
@@ -48,6 +50,7 @@ export default [
     external: isExternal,
     plugins: [
       nodeResolve(),
+      typescript({ tsconfig: path.resolve(__dirname, 'tsconfig.json') }),
       babel({ babelHelpers: 'bundled' }),
       // Put the Codecov rollup plugin after all other plugins
       codecovRollupPlugin({

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types",
+    "rootDir": "./src",
+    "composite": true,
+    "allowJs": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "skipLibCheck": true
+  },
+  "files": [],
+  "references": [
+    { "path": "./packages/changelog-github" },
+    { "path": "./packages/codemod" },
+    { "path": "./packages/react-base" },
+    { "path": "./packages/react-docs" },
+    { "path": "./packages/react-hooks" },
+    { "path": "./packages/react-icons" },
+    { "path": "./packages/react" },
+    { "path": "./packages/styled-system" },
+    { "path": "./packages/theme" },
+    { "path": "./packages/utils" }
+  ]
+}


### PR DESCRIPTION
## Summary
- install TypeScript utilities in the root package.json
- set up a workspace tsconfig.json with project references
- add per-package tsconfig.json files
- update package Rollup configs to compile TypeScript sources
- add missing rollup plugin dependency and base options

## Testing
- `CI=true yarn test`